### PR TITLE
Reduce column size to fit utf8mb4 index

### DIFF
--- a/Resources/config/doctrine/mappings/Topic.orm.xml
+++ b/Resources/config/doctrine/mappings/Topic.orm.xml
@@ -14,7 +14,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="topicArn" type="string" column="topic_arn" length="1024" />
+        <field name="topicArn" type="string" column="topic_arn" length="296" />
         <field name="token" type="string" length="1024" column="token" nullable="true" />
 
     </entity>


### PR DESCRIPTION
As you set an index on the topic_arn property of the Topic entity, creation of the table fails in an InnoDB database with default character set utf8mb4:

> Syntax error or access violation: 1071 Specified key was too long; max key length is 3072 bytes' while executing DDL: CREATE TABLE aws_ses_monitor_topics (id INT AUTO_INCREMENT NOT NULL, topic_arn VARCHAR(1024) NOT NULL, token VARCHAR(1024) DEFAULT NULL, INDEX topic (topic_arn), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin ENGINE = InnoDB

The topic_arn is unnecessarily big as it will never exceed 296 characters.

`arn:partition:service:region:account-id:resource`

arn: 3
partition: 3 (aws)
service: 3 (sns)
region: 14 (longest region identifier is `ap-northeast-2`)
account-id: 12
resource: 256

Including the 5 colons, this adds up to 296.
